### PR TITLE
change applicationId to “mm.tencent.com.comtencentmmhardcodertest”

### DIFF
--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "com.tencent.mm.hardcoder.testapp"
+        applicationId "mm.tencent.com.comtencentmmhardcodertest"
         minSdkVersion 22
         targetSdkVersion 28
         versionCode 1

--- a/testapp/src/main/java/com/tencent/mm/hardcoder/testapp/QuickStart.java
+++ b/testapp/src/main/java/com/tencent/mm/hardcoder/testapp/QuickStart.java
@@ -98,9 +98,9 @@ public class QuickStart extends Activity {
                 //cert为testapp在OPPO手机上生成的key,具体值请向厂商申请生成
                 //manufacture和cert均为数组，可同时传多个厂商的值
                 String[] manufactures = {"OPPO"};
-                String[] certs = {"gAnwcqfqFGGwTgX2MwdiBwikz9o8N/Tggq7pC6FuUaWME6/FbcMgFZFsFJR47P0Wo9My6" +
-                        "cVYjotaa7njDlrGBIQ1PeSGPxiSN1LaC2tpRcOTzU8K1eUry3x/A0FdzM/gt+g9TEtuTH4WvhjVf3f" +
-                        "qbnQjKrSl1jsOKIjn/4FtWsg="};
+                String[] certs = {"K6dLGcYfPdHbdbnOwbXe7tXc3sySDV0IZoJ4u7CSB7yPpSJ2xb2lrHbHyIwrzNhuc88kuehvY" +
+                        "MQhVsx6X8nOks0lfvTyNoOOYpX/3UinFnbSPvlXOt9U+v3sXhJPqbU7zR6fjghJ" +
+                        "hfZYxSs+lOMgg1qwv0A0duXMEJWCzU+tnZ4="};
                 final long requestId = HardCoderJNI.checkPermission(manufactures, certs,
                         new HardCoderCallback.FuncRetCallback() {
                         @Override

--- a/testapp/src/main/java/com/tencent/mm/hardcoder/testapp/TestAPIs.java
+++ b/testapp/src/main/java/com/tencent/mm/hardcoder/testapp/TestAPIs.java
@@ -103,9 +103,9 @@ public class TestAPIs extends Activity {
                 //cert为testapp在OPPO手机上生成的key,具体值请向厂商申请生成
                 //manufacture和cert均为数组，可同时传多个厂商的值
                 String[] manufactures = {"OPPO"};
-                String[] certs = {"gAnwcqfqFGGwTgX2MwdiBwikz9o8N/Tggq7pC6FuUaWME6/FbcMgFZFsFJR47P0Wo9My6" +
-                        "cVYjotaa7njDlrGBIQ1PeSGPxiSN1LaC2tpRcOTzU8K1eUry3x/A0FdzM/gt+g9TEtuTH4WvhjVf3f" +
-                        "qbnQjKrSl1jsOKIjn/4FtWsg="};
+                String[] certs = {"K6dLGcYfPdHbdbnOwbXe7tXc3sySDV0IZoJ4u7CSB7yPpSJ2xb2lrHbHyIwrzNhuc88kuehvY" +
+                        "MQhVsx6X8nOks0lfvTyNoOOYpX/3UinFnbSPvlXOt9U+v3sXhJPqbU7zR6fjghJ" +
+                        "hfZYxSs+lOMgg1qwv0A0duXMEJWCzU+tnZ4="};
                 final long requestId = HardCoderJNI.checkPermission(manufactures, certs,
                         new HardCoderCallback.FuncRetCallback() {
                         @Override


### PR DESCRIPTION
Some manufactures like vivo hardcode this applicationId as testapp to approve to use Hardcoder before.
修改testapp的包名。部分厂商hardcode了testapp的包名，开源前testapp使用了新的包名导致在vivo手机上testapp不能使用Hardcoder。